### PR TITLE
Optimize Excel upload signal handling

### DIFF
--- a/account/utils.py
+++ b/account/utils.py
@@ -1,6 +1,7 @@
 import secrets
 
 import re
+from contextlib import contextmanager
 
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
@@ -146,3 +147,17 @@ def get_cache_key(prefix, user, child_id=None, **kwargs):
         key += f"_{k}_{v}"
     print("[get_cache_key]", key)
     return key
+
+
+@contextmanager
+def disable_signals(signal_receiver_pairs):
+    """Temporarily disconnect model signals."""
+    disconnected = []
+    try:
+        for signal, receiver, sender in signal_receiver_pairs:
+            signal.disconnect(receiver, sender)
+            disconnected.append((signal, receiver, sender))
+        yield
+    finally:
+        for signal, receiver, sender in disconnected:
+            signal.connect(receiver, sender)


### PR DESCRIPTION
## Summary
- add helper to temporarily disable signals
- disable cache signals during Excel upload
- batch invalidate caches after processing users

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `make run` *(fails: Couldn't import Django)*
- `make celery` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684693dc83ac83329ddf225b6fd627a2